### PR TITLE
JWT Service

### DIFF
--- a/jwt/JsonWebToken.java
+++ b/jwt/JsonWebToken.java
@@ -1,0 +1,22 @@
+package com.smoothstack.lms.common.jwt;
+
+public class JsonWebToken {
+    private String token = "";
+
+    public JsonWebToken(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public String toString() {
+        return token;
+    }
+}

--- a/jwt/JwtServices.java
+++ b/jwt/JwtServices.java
@@ -1,0 +1,111 @@
+package com.smoothstack.lms.common.jwt;
+
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+
+@Service
+public class JwtServices {
+    private Logger logger = LoggerFactory.getLogger(JwtServices.class);
+
+    private SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS512;
+
+    @Value("${jwt.secret:generate}")
+    private String signingKey;
+
+    private String generateNewSecretKey() {
+
+        SecretKey key =  Keys.secretKeyFor(signatureAlgorithm);
+        return Encoders.BASE64.encode(key.getEncoded()).toUpperCase();
+
+    }
+
+    public String getSigningKey() {
+        if (!signingKey.startsWith("HS512:")) {
+            String key = generateNewSecretKey();
+            logger.warn("=======================================================================");
+            logger.warn(" Warning: The JWT secret key will be invalid when restart server.      ");
+            logger.warn("          Please add the following key to your application.properties. ");
+            logger.warn("=======================================================================");
+            logger.warn(String.format("jwt.secret = HS512:%s", key ));
+            return key;
+        } else {
+            return signingKey.replaceAll("^HS512:","");
+        }
+    }
+
+
+    public JsonWebToken getJasonWebToken(UserDetails userDetails) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String serializedAuthorities = objectMapper.writeValueAsString(userDetails.getAuthorities());
+
+        SecretKey secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(getSigningKey()));
+
+        String signedToken = Jwts.builder()
+                .setId(UUID.randomUUID().toString())
+                .setIssuer("Smoothstack, Inc.")
+                .setSubject(userDetails.getUsername())
+                .claim("authorities", serializedAuthorities)
+                .signWith(secretKey)
+                .compact();
+
+        return new JsonWebToken(signedToken);
+    }
+
+    public JwtParser getJwtParser() {
+        SecretKey secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(getSigningKey()));
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build();
+    }
+
+    public UserDetails getUserDetails(JsonWebToken jsonWebToken, Function<Jws<Claims>, UserDetails> extractFunction) {
+        Jws<Claims> jws = getJwtParser().parseClaimsJws(jsonWebToken.getToken());
+
+        return extractFunction.apply(jws);
+    }
+
+    public static UserDetails extractFromTrustedSource(Jws<Claims> jws)  {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            User.UserBuilder userBuilder = User.withUsername(jws.getBody().getSubject());
+            userBuilder.password(jws.getSignature());
+
+            ObjectMapper mapper = new ObjectMapper();
+            JsonFactory factory = mapper.getFactory();
+            JsonParser parser = factory.createParser(jws.getBody().get("authorities").toString());
+            JsonNode node = mapper.readTree(parser);
+
+            Set<String> authorities = new HashSet<>();
+            node.iterator().forEachRemaining(
+                    s -> authorities.add(s.get("authority").asText())
+            );
+
+            userBuilder.authorities(authorities.toArray(new String[0]));
+
+            return userBuilder.build();
+        }
+        catch (Exception ignored) {}
+        return null;
+    }
+}

--- a/security/CommonSecurityConfiguration.java
+++ b/security/CommonSecurityConfiguration.java
@@ -49,12 +49,15 @@ public class CommonSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
         httpSecurity
                 .authorizeRequests()
+                .antMatchers("/security-test/administrator/**").hasRole("TEST_ADMIN")
                 .antMatchers("/security-test/admin/**").hasRole("TEST_ADMIN")
                 .antMatchers("/security-test/librarian/**").hasRole("TEST_LIBRARIAN")
-                .antMatchers("/security-test/borrower/**").hasRole("TEST_BORROWER");
+                .antMatchers("/security-test/borrower/**").hasRole("TEST_BORROWER")
+                .antMatchers("/security-test/**").permitAll();
 
         httpSecurity
                 .authorizeRequests()
+                .antMatchers("/administrator/**").hasRole("ADMIN")
                 .antMatchers("/admin/**").hasRole("ADMIN")
                 .antMatchers("/librarian/**").hasRole("LIBRARIAN")
                 .antMatchers("/borrower/**").hasRole("BORROWER");
@@ -67,8 +70,6 @@ public class CommonSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 )
                 .permitAll();
 
-
-
         if (h2ConsoleEnabled) {
             httpSecurity.authorizeRequests().antMatchers(h2ConsolePath + "/**").permitAll();
 
@@ -77,6 +78,9 @@ public class CommonSecurityConfiguration extends WebSecurityConfigurerAdapter {
             httpSecurity.headers().frameOptions().disable();
         }
 
+        httpSecurity.authorizeRequests()
+                .anyRequest()
+                .denyAll();
 
     }
 

--- a/security/SecurityTestController.java
+++ b/security/SecurityTestController.java
@@ -1,19 +1,37 @@
 package com.smoothstack.lms.common.security;
 
+import com.smoothstack.lms.common.jwt.JsonWebToken;
+import com.smoothstack.lms.common.jwt.JwtServices;
 import com.smoothstack.lms.common.util.Response;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
 
 @Controller
 @RequestMapping("/security-test")
 public class SecurityTestController {
+    @Autowired
+    private JwtServices jwtServices;
+    /**
+     * With correct configuration, only request with proper JWT will be able to access this resource
+     * @param principal Spring boot principal
+     * @param servletRequest Java Servlet Request
+     * @return Information about request
+     */
 
-    @RequestMapping(path = {"/admin","/librarian","/borrower"}  )
+    @RequestMapping(path = {"/administrator","/librarian","/borrower"}  )
     public ResponseEntity testJwtAccessControl(Principal principal, HttpServletRequest servletRequest) {
         Response response = new Response();
         response.getPayload().setStatus(HttpStatus.OK);
@@ -32,5 +50,61 @@ public class SecurityTestController {
         response.getPayload().getResponse().put("message", "Success!");
 
         return response.buildResponseEntity();
+    }
+
+    @RequestMapping (
+            method = RequestMethod.POST,
+            path = {"/generate-test-token"}
+    )
+    public ResponseEntity generateTestToken(
+            @RequestParam(defaultValue = "test") String username,
+            @RequestParam(required = false) List<String> authorities) {
+        try {
+
+        User.UserBuilder userBuilder = User.withUsername(username);
+        userBuilder.password("");
+        if (authorities != null)
+            userBuilder.authorities(
+                    authorities.stream()
+                    .map(s->String.format("TEST_%s", s.trim().toUpperCase()))
+                    .toArray(String[]::new));
+        else
+            userBuilder.authorities(Collections.emptyList());
+
+        JsonWebToken token = jwtServices.getJasonWebToken(userBuilder.build());
+
+        Response response = Response.code(HttpStatus.OK);
+
+        response.getPayload().getRequest().put("userDetails", userBuilder.build());
+
+        response.getPayload().getResponse().put("jws", token);
+
+        return response.buildResponseEntity();
+
+        } catch (Exception e) {
+            Response response = Response.code(HttpStatus.BAD_REQUEST);
+            response.getPayload().getResponse().put("message", e.getMessage());
+            response.getPayload().getResponse().put("exception", e);
+            return response.buildResponseEntity();
+        }
+
+    }
+
+    @RequestMapping (
+            method = RequestMethod.GET,
+            path = {"/claim-test-token"},
+            produces = {MediaType.APPLICATION_JSON_VALUE}
+    )
+    public ResponseEntity<Object> claimTestToken(@RequestHeader("Proxy-Authorization") String proxyAuthorization) {
+        if (null == proxyAuthorization) {
+            return ResponseEntity.badRequest().body("Header missing 'Proxy-Authorization: JWT <jwt-token>'");
+        }
+        if (!proxyAuthorization.startsWith("JWT ")) {
+            return ResponseEntity.badRequest().body("Token not start with 'JWT' string.");
+        }
+
+        JsonWebToken token = new JsonWebToken(proxyAuthorization.substring(4));
+
+        return ResponseEntity.ok(jwtServices.getUserDetails(token, JwtServices::extractFromTrustedSource));
     }
 }

--- a/util/Response.java
+++ b/util/Response.java
@@ -38,6 +38,14 @@ public class Response {
         payload.getMeta().values().forEach(LoopTerminator::apply);
         return ResponseEntity.status(payload.getStatus()).body(payload);
     }
+
+    public static Response code(HttpStatus status) {
+        Response response = new Response();
+
+        response.getPayload().setStatus(status);
+
+        return response;
+    }
 }
 
 


### PR DESCRIPTION
Auto Generate JWT Secret using HMAC SHA 512 Algorithm if jwt.secret is not configured

Store JWT Secret in Base64 format
Restore JWT Secret from Base64 to Key using core java API (not rely on 3rd party)

Implement UUID for Jwt

Support Embeded Authorities

Support ExtractFromTrustedSource

Add both '/admin' and '/administrator' to Configuration

Add denyAll for Security

Add test case to class SecurityTestController

POST /security-test/generate-test-token?username=<user>&authorities=AUTHORITY1,AUTHORITY2
will generate JWT

GET /security-test/claim-test-token
Proxy-Authorization: JWT <jwt-token>
will return UserDetails as JSON


